### PR TITLE
Speed up command line runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,18 @@ To build:
 sbt compile
 ```
 
+#### Faster runs
+
+Build once with:
+
+```
+sbt assembly
+```
+Run with:
+```
+java -jar target/scala-2.11/tip-assembly-2.0.0.jar -run example/fib.tip
+```
+
 ## Command-line arguments <a name="tipcmd"></a>
 
 Usage:

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,4 @@
 logLevel := Level.Warn
 
 addSbtPlugin("com.lucidchart" % "sbt-scalafmt" % "1.10")
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.6")


### PR DESCRIPTION
Now running tip from the command line is very slow, because it compiles every time. 
I have added [sbt-assembly](https://github.com/sbt/sbt-assembly) plugin so that we can compile tip to jar and run it faster.