### PR TITLE
Bump Scala version to 2.12.9

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 name := "tip"
 
-scalaVersion := "2.12.8"
+scalaVersion := "2.12.9"
 
 trapExit := false
 


### PR DESCRIPTION
Compiling with Scala version 2.12.8 with OpenJDK 14 causes a crash. [A similar issue](https://github.com/sbt/sbt/issues/5093) happened in the transition to OpenJDK 13.