### PR TITLE
Fix link to course website

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 TIP is a tiny imperative programming language aimed at teaching the
 fundamental concepts of static program analysis. This code accompanies the
-lecture notes on [Static Program Analysis](http://cs.au.dk/~amoeller/spa/).
+lecture notes on [Static Program Analysis](https://cs.au.dk/~amoeller/spa/).
 
 ## Getting started
 


### PR DESCRIPTION
Looks like the Aarhus webserver has a problem with redirecting http to https and introduces a spurious `/`.  Using https directly avoids this issue.