### PR TITLE
Bump Scala version to be compatible with recent JDK versions

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 name := "tip"
 
-scalaVersion := "2.12.12"
+scalaVersion := "2.12.20"
 
 trapExit := false
 


### PR DESCRIPTION
Without this, building TIP fails on recent JDK versions like JDK 21.  Here's what I saw on JDK 21 before the change:

```
$ ./tip -run examples/signs.tip
[info] Updated file /private/tmp/TIP/project/build.properties: set sbt.version to 1.10.11
[info] welcome to sbt 1.10.11 (Eclipse Adoptium Java 21.0.6)
[info] loading global plugins from /Users/msridhar/.sbt/1.0/plugins
[info] loading settings for project tip-build from plugins.sbt...
[info] loading project definition from /private/tmp/TIP/project
[info] loading settings for project tip from build.sbt...
[info] set current project to tip (in build file:/private/tmp/TIP/)
[info] compiling 62 Scala sources to /private/tmp/TIP/target/scala-2.12/classes ...
[info] Non-compiled module 'compiler-bridge_2.12' for Scala 2.12.12. Compiling...
error:
  bad constant pool index: 0 at pos: 484540s
     while compiling: <no file>
        during phase: globalPhase=<no phase>, enteringPhase=<some phase>
     library version: version 2.12.12
    compiler version: version 2.12.12
```